### PR TITLE
Remove Japanese label from index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,8 @@
             <div class="col-12 col-md-6 col-lg-6">
               <div class="card shadow-sm">
                 <div class="card-body">
-                  <h4 class="card-title">日本語<small class="text-muted"> Japanese</small></h4>
-                  <a href="./ja/" class="card-link btn btn-primary">トップページへ</a>
+                  <h4 class="card-title">Japanese</h4>
+                  <a href="./ja/" class="card-link btn btn-primary">Go to Top Page</a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Replace Japanese label in landing page with English text

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68c0bc12bbcc8320b9ae8126fbf3ae93