### PR TITLE
Validate Hong Kong mobile numbers

### DIFF
--- a/en-US/reserve.html
+++ b/en-US/reserve.html
@@ -101,8 +101,8 @@
             </div>
             <div class="form-group d-none">
               <label for="tel">Tel <span class="badge badge-primary">required</span></label>
-              <input type="tel" class="form-control" name="tel" id="tel" pattern="[0-9]{11}" disabled>
-              <small class="form-text text-muted">Please enter 11-digit number. Ex: 01133335555</small>
+              <input type="tel" class="form-control" name="tel" id="tel" pattern="[5689][0-9]{7}" disabled>
+                <small class="form-text text-muted">Please enter 8-digit number. Ex: 51234567</small>
               <div class="invalid-feedback"></div>
             </div>
             <div class="form-group">

--- a/en-US/signup.html
+++ b/en-US/signup.html
@@ -88,8 +88,8 @@
             </div>
             <div class="form-group">
               <label for="tel">Tel</label>
-              <input type="tel" class="form-control" name="tel" id="tel" pattern="[0-9]{11}">
-              <small class="form-text text-muted">Please enter 11-digit number. Ex: 01133335555</small>
+              <input type="tel" class="form-control" name="tel" id="tel" pattern="[5689][0-9]{7}">
+                <small class="form-text text-muted">Please enter 8-digit number. Ex: 51234567</small>
               <div class="invalid-feedback"></div>
             </div>
             <div class="form-group">

--- a/ja/reserve.html
+++ b/ja/reserve.html
@@ -101,8 +101,8 @@
             </div>
             <div class="form-group d-none">
               <label for="tel">電話番号 <span class="badge badge-primary">必須</span></label>
-              <input type="tel" class="form-control" name="tel" id="tel" pattern="[0-9]{11}" disabled>
-              <small class="form-text text-muted">11桁の数字で入力してください。例：01133335555</small>
+              <input type="tel" class="form-control" name="tel" id="tel" pattern="[5689][0-9]{7}" disabled>
+                <small class="form-text text-muted">8桁の数字で入力してください。例：51234567</small>
               <div class="invalid-feedback"></div>
             </div>
             <div class="form-group">

--- a/ja/signup.html
+++ b/ja/signup.html
@@ -87,11 +87,11 @@
               <div class="invalid-feedback"></div>
             </div>
             <div class="form-group">
-              <label for="tel">電話番号</label>
-              <input type="tel" class="form-control" name="tel" id="tel" pattern="[0-9]{11}">
-              <small class="form-text text-muted">11桁の数字で入力してください。例：01133335555</small>
-              <div class="invalid-feedback"></div>
-            </div>
+                <label for="tel">電話番号</label>
+                <input type="tel" class="form-control" name="tel" id="tel" pattern="[5689][0-9]{7}">
+                <small class="form-text text-muted">8桁の数字で入力してください。例：51234567</small>
+                <div class="invalid-feedback"></div>
+              </div>
             <div class="form-group">
               <label for="gender">性別</label>
               <select class="form-control" name="gender" id="gender">


### PR DESCRIPTION
## Summary
- restrict tel fields to 8‑digit Hong Kong mobile numbers
- update help text to reflect Hong Kong format in English and Japanese signup and reservation forms

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c13ee7e0648320b3ea788a9234b0fc